### PR TITLE
Automatically compile kernel with github actions

### DIFF
--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -20,6 +20,9 @@ jobs:
         EOF
 
         docker run -t -v $PWD:/build archlinux /bin/bash /build/entrypoint.sh
+    
+    - name: Print sha512sums
+      run: sha512sum *.pkg.tar*
 
     - name: Upload Arch package
       uses: actions/upload-artifact@v2
@@ -33,9 +36,16 @@ jobs:
         source PKGBUILD
         echo "::set-output name=tag::${pkgver}-${pkgrel}"
         echo $pkgver $pkgrel
+        if ! curl -s https://github.com/Redecorating/mbp-16.1-linux-wifi/releases/tag/v${pkgver}-${pkgrel} > /dev/null
+        then RELEASE=true
+        else RELEASE=false
+        fi
+        echo Release: $RELEASE
+        echo "::set-output name=RELEASE::${RELEASE}"
           
     - name: Release
       uses: softprops/action-gh-release@v1
+      if: ${{ steps.create_tag.outputs.RELEASE == "true" }}
       with:
          files: |
            ${{ github.workspace }}/*.pkg.tar.*

--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -15,7 +15,7 @@ jobs:
         pacman -Syu --noconfirm --needed sudo base-devel
         printf 'builduser ALL=(ALL) ALL\\n' | tee -a /etc/sudoers
         chown -R builduser:builduser ./
-        sudo -u builduser gpg --keyserver pgp.mit.edu --recv-keys 38DBBDC86092693E
+        sudo -u builduser gpg --keyserver keyserver.ubuntu.com --recv-keys 38DBBDC86092693E
         sudo -u builduser bash -c 'export MAKEFLAGS=j\$(nproc) && makepkg -s --noconfirm'
         EOF
 

--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -37,7 +37,7 @@ jobs:
         echo "::set-output name=tag::${pkgver}-${pkgrel}"
         echo $pkgver $pkgrel
         if curl -s https://github.com/Redecorating/mbp-16.1-linux-wifi/releases/tag/v${pkgver}-${pkgrel} > /dev/null
-        then rm *.pkg.tar.*
+        then sudo rm *.pkg.tar.*
         fi
           
     - name: Release

--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -1,0 +1,123 @@
+name: Build Kernel Package
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Build in Docker
+      run: |
+        cat << EOF > entrypoint.sh
+        cd /build
+        useradd builduser -m
+        passwd -d builduser
+        pacman -Syu --noconfirm --needed sudo base-devel
+        printf 'builduser ALL=(ALL) ALL\\n' | tee -a /etc/sudoers
+        chown -R builduser:builduser ./
+        sudo -u builduser gpg --keyserver hkp://keys.gnupg.net:80 --recv-keys 38DBBDC86092693E
+        sudo -u builduser bash -c 'export MAKEFLAGS=j\$(nproc) && makepkg -s --noconfirm'
+        EOF
+
+        docker run -t -v $PWD:/build archlinux /bin/bash /build/entrypoint.sh
+
+    - name: Upload Arch package
+      uses: actions/upload-artifact@v2
+      with:
+        name: mbp-16.1-linux-wifi-arch
+        path: ${{ github.workspace }}/mbp-16.1-linux-wifi-*-x86_64.pkg.tar.zst
+        
+    - name: Package for Debian
+      id: create_tag
+      run: |
+        source PKGBUILD
+        echo "::set-output name=tag::${pkgver}-${pkgrel}"
+        sudo chown -R $USER:$USER .
+
+        for i in ${pkgname[@]}
+        do rm -v pkg/$i/.???*
+        mkdir -v pkg/$i/DEBIAN
+        
+        cat << EOF > pkg/$i/DEBIAN/control
+        Package: $i
+        Version: $pkgver
+        Architecture: amd64
+        Section: kernel
+        EOF
+        
+        done
+
+        for i in postinst postrm preinst prerm
+        do cat << EOF > pkg/${pkgname[0]}/DEBIAN/$i
+        #!/bin/sh
+
+        set -e
+
+        # Pass maintainer script parameters to hook scripts
+        export DEB_MAINT_PARAMS="$*"
+
+        # Tell initramfs builder whether it's wanted
+        export INITRD=Yes
+
+        test -d /etc/kernel/${i}.d && run-parts --arg="$pkgver-${pkgrel}${pkgbase}" --arg="/boot/vmlinuz-$pkgver-${pkgrel}${pkgbase}" /etc/kernel/${i}.d
+        exit 0
+        EOF
+        chmod 755 pkg/${pkgname[0]}/DEBIAN/$i
+        done
+
+        for i in ${pkgname[@]}
+        do cat pkg/$i/DEBIAN/*
+        dpkg -b pkg/$i $i-$pkgver-$pkgrel.deb
+        done
+        
+    - name: Upload Debian package
+      uses: actions/upload-artifact@v2
+      with:
+        name: mbp-16.1-linux-wifi-debian
+        path: ${{ github.workspace }}/*.deb
+
+
+    - name: Zip packages
+      run: |
+        zip mbp-16.1-linux-wifi-arch-${{ steps.create_tag.outputs.tag }}.zip *.pkg.tar.*
+        zip mbp-16.1-linux-wifi-debian-${{ steps.create_tag.outputs.tag }}.zip *.deb
+        
+    - name: Create draft release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.create_tag.outputs.tag }}
+        release_name: ${{ steps.create_tag.outputs.tag }}
+        draft: true
+        prerelease: false
+
+
+    - name: Add Debian package to release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/mbp-16.1-linux-wifi-debian-${{ steps.create_tag.outputs.tag }}.zip
+        asset_name: mbp-16.1-linux-wifi-debian-${{ steps.create_tag.outputs.tag }}.zip
+        asset_content_type: application/zip
+
+    - name: Add Arch package to release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/mbp-16.1-linux-wifi-arch-${{ steps.create_tag.outputs.tag }}.zip
+        asset_name: mbp-16.1-linux-wifi-arch-${{ steps.create_tag.outputs.tag }}.zip
+        asset_content_type: application/zip
+          
+#    - name: Publish release
+#      uses: eregon/publish-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        release_id: ${{ steps.create_release.outputs.id }}
+

--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -15,7 +15,7 @@ jobs:
         pacman -Syu --noconfirm --needed sudo base-devel
         printf 'builduser ALL=(ALL) ALL\\n' | tee -a /etc/sudoers
         chown -R builduser:builduser ./
-        sudo -u builduser gpg --keyserver hkp://keys.gnupg.net:80 --recv-keys 38DBBDC86092693E
+        sudo -u builduser gpg --keyserver pgp.mit.edu --recv-keys 38DBBDC86092693E
         sudo -u builduser bash -c 'export MAKEFLAGS=j\$(nproc) && makepkg -s --noconfirm'
         EOF
 

--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -36,16 +36,12 @@ jobs:
         source PKGBUILD
         echo "::set-output name=tag::${pkgver}-${pkgrel}"
         echo $pkgver $pkgrel
-        if ! curl -s https://github.com/Redecorating/mbp-16.1-linux-wifi/releases/tag/v${pkgver}-${pkgrel} > /dev/null
-        then RELEASE=true
-        else RELEASE=false
+        if curl -s https://github.com/Redecorating/mbp-16.1-linux-wifi/releases/tag/v${pkgver}-${pkgrel} > /dev/null
+        then rm *.pkg.tar.*
         fi
-        echo Release: $RELEASE
-        echo "::set-output name=RELEASE::${RELEASE}"
           
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: ${{ steps.create_tag.outputs.RELEASE == "true" }}
       with:
          files: |
            ${{ github.workspace }}/*.pkg.tar.*

--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -27,97 +27,27 @@ jobs:
         name: mbp-16.1-linux-wifi-arch
         path: ${{ github.workspace }}/mbp-16.1-linux-wifi-*-x86_64.pkg.tar.zst
         
-    - name: Package for Debian
+    - name: create tag
       id: create_tag
       run: |
         source PKGBUILD
         echo "::set-output name=tag::${pkgver}-${pkgrel}"
-        sudo chown -R $USER:$USER .
-
-        for i in ${pkgname[@]}
-        do rm -v pkg/$i/.???*
-        mkdir -v pkg/$i/DEBIAN
-        
-        cat << EOF > pkg/$i/DEBIAN/control
-        Package: $i
-        Version: $pkgver
-        Architecture: amd64
-        Section: kernel
-        EOF
-        
-        done
-
-        for i in postinst postrm preinst prerm
-        do cat << EOF > pkg/${pkgname[0]}/DEBIAN/$i
-        #!/bin/sh
-
-        set -e
-
-        # Pass maintainer script parameters to hook scripts
-        export DEB_MAINT_PARAMS="$*"
-
-        # Tell initramfs builder whether it's wanted
-        export INITRD=Yes
-
-        test -d /etc/kernel/${i}.d && run-parts --arg="$pkgver-${pkgrel}${pkgbase}" --arg="/boot/vmlinuz-$pkgver-${pkgrel}${pkgbase}" /etc/kernel/${i}.d
-        exit 0
-        EOF
-        chmod 755 pkg/${pkgname[0]}/DEBIAN/$i
-        done
-
-        for i in ${pkgname[@]}
-        do cat pkg/$i/DEBIAN/*
-        dpkg -b pkg/$i $i-$pkgver-$pkgrel.deb
-        done
-        
-    - name: Upload Debian package
-      uses: actions/upload-artifact@v2
-      with:
-        name: mbp-16.1-linux-wifi-debian
-        path: ${{ github.workspace }}/*.deb
-
-
-    - name: Zip packages
-      run: |
-        zip mbp-16.1-linux-wifi-arch-${{ steps.create_tag.outputs.tag }}.zip *.pkg.tar.*
-        zip mbp-16.1-linux-wifi-debian-${{ steps.create_tag.outputs.tag }}.zip *.deb
-        
-    - name: Create draft release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ steps.create_tag.outputs.tag }}
-        release_name: ${{ steps.create_tag.outputs.tag }}
-        draft: true
-        prerelease: false
-
-
-    - name: Add Debian package to release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/mbp-16.1-linux-wifi-debian-${{ steps.create_tag.outputs.tag }}.zip
-        asset_name: mbp-16.1-linux-wifi-debian-${{ steps.create_tag.outputs.tag }}.zip
-        asset_content_type: application/zip
-
-    - name: Add Arch package to release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/mbp-16.1-linux-wifi-arch-${{ steps.create_tag.outputs.tag }}.zip
-        asset_name: mbp-16.1-linux-wifi-arch-${{ steps.create_tag.outputs.tag }}.zip
-        asset_content_type: application/zip
+        echo $pkgver $pkgrel
           
-#    - name: Publish release
-#      uses: eregon/publish-release@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        release_id: ${{ steps.create_release.outputs.id }}
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+         files: |
+           ${{ github.workspace }}/*.pkg.tar.*
+         tag_name: v${{ steps.create_tag.outputs.tag }}
+         draft: true
+         body: |
+          Install packages with `sudo pacman -U <file>`, you can use urls or file paths.
+          You will need to be using `apple-bce-dkms-git` as `apple-bce-git` only works on `linux-mbp`.
+          If you are looking for a debian version of this, see [here](https://github.com/Redecorating/mbp-ubuntu-kernel/releases)
+          
+          You will need wifi firmware from MacOS, as described [here](https://wiki.t2linux.org/guides/wifi/#on-macos).
+      env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 


### PR DESCRIPTION
Builds the package in an arch docker container, and uploads it as a build artifact. It then packages it as a .deb, which I can't test. That also gets uploaded as a build artifact. 

At the end, it automatically creates a draft release with both the arch and debian packages.
