### PR TITLE
Fixed issue causing CI unable to release

### DIFF
--- a/.github/workflows/BuildKernelPackage.yml
+++ b/.github/workflows/BuildKernelPackage.yml
@@ -36,9 +36,6 @@ jobs:
         source PKGBUILD
         echo "::set-output name=tag::${pkgver}-${pkgrel}"
         echo $pkgver $pkgrel
-        if curl -s https://github.com/Redecorating/mbp-16.1-linux-wifi/releases/tag/v${pkgver}-${pkgrel} > /dev/null
-        then sudo rm *.pkg.tar.*
-        fi
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
@@ -49,9 +46,7 @@ jobs:
          body: |
           Install packages with `sudo pacman -U <file>`, you can use urls or file paths.
           You will need to be using `apple-bce-dkms-git` as `apple-bce-git` only works on `linux-mbp`.
-          If you are looking for a debian version of this, see [here](https://github.com/Redecorating/mbp-ubuntu-kernel/releases)
           You will need wifi firmware from MacOS, as described [here](https://wiki.t2linux.org/guides/wifi/#on-macos).
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 


### PR DESCRIPTION
You may have to delete releases related to 5.13.10 and stop other workflows in progress before merging.