### PR TITLE
5.13.13 + md5 generator

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
 
 pkgbase=mbp-16.1-linux-wifi
-pkgver=5.13.12
+pkgver=5.13.13
 _srcname=linux-${pkgver}
 pkgrel=1
 pkgdesc='Linux for MBP 16.1 Wifi'
@@ -236,7 +236,7 @@ for _p in "${pkgname[@]}"; do
   }"
 done
 
-md5sums=('6e1728b2021ca19cc9273f080e6c44c7'
+md5sums=('392cd7526637b3cbdf9de748d9a9008e'
          'SKIP'
          '1e81a7ec51b2824fa0b4adf8371482b1'
          '080dee4dd14a43c2c131aa907b5a6045'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mbp-16.1-linux-wifi - 5.13.12
+mbp-16.1-linux-wifi - 5.13.13
 ==============
 
 Arch Linux package for Linux kernel with bleeding edge 2018+ MacBook Pro support.


### PR DESCRIPTION
I've made a repo to get md5 sums of linux kernel using github actions [here](https://github.com/AdityaGarg8/md5-generator/runs/3434948340?check_suite_focus=true)

If you want to use this, fork this repo, enable the workflows and edit the kernel version in the yml file in .github/workflows. Then go to actions and get the md5 sums from the log of the triggered workflow. Takes just a few seconds to generate.