### PR TITLE
Revert "5.15"

### DIFF
--- a/8001-corellium-wifi-bigsur.patch
+++ b/8001-corellium-wifi-bigsur.patch
@@ -40,9 +40,9 @@ index 5bf11e46fc49a..4058edddbdc23 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/chip.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/chip.c
 @@ -726,6 +726,8 @@ static u32 brcmf_chip_tcm_rambase(struct brcmf_chip_priv *ci)
+ 	case BRCM_CC_4364_CHIP_ID:
+ 	case CY_CC_4373_CHIP_ID:
  		return 0x160000;
- 	case CY_CC_43752_CHIP_ID:
- 		return 0x170000;
 +	case BRCM_CC_4378_CHIP_ID:
 +		return 0x352000;
  	default:
@@ -779,7 +779,7 @@ index c6c4be05159d4..083cc6927417e 100644
 +#define BRCM_CC_4378_CHIP_ID		0x4378
  #define CY_CC_4373_CHIP_ID		0x4373
  #define CY_CC_43012_CHIP_ID		43012
- #define CY_CC_43752_CHIP_ID		43752
+ 
 @@ -83,6 +84,7 @@
  #define BRCM_PCIE_4366_2G_DEVICE_ID	0x43c4
  #define BRCM_PCIE_4366_5G_DEVICE_ID	0x43c5

--- a/8002-Add-support-for-BCM4377.patch
+++ b/8002-Add-support-for-BCM4377.patch
@@ -18,9 +18,9 @@ index 1bf0fa8f0..1e1b23bf4 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/chip.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/chip.c
 @@ -727,6 +727,8 @@ static u32 brcmf_chip_tcm_rambase(struct brcmf_chip_priv *ci)
+ 	case BRCM_CC_4364_CHIP_ID:
+ 	case CY_CC_4373_CHIP_ID:
  		return 0x160000;
- 	case CY_CC_43752_CHIP_ID:
- 		return 0x170000;
 +	case BRCM_CC_4377_CHIP_ID:
 +		return 0x170000;
  	case BRCM_CC_4378_CHIP_ID:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
 
 pkgbase=mbp-16.1-linux-wifi
-pkgver=5.15
+pkgver=5.14.13
 _srcname=linux-${pkgver}
 pkgrel=1
 pkgdesc='Linux for MBP 16.1 Wifi'
@@ -238,7 +238,7 @@ for _p in "${pkgname[@]}"; do
   }"
 done
 
-sha256sums=('57b2cf6991910e3b67a1b3490022e8a0674b6965c74c12da1e99d138d1991ee8'
+sha256sums=('832b78b4c098a99f5c0c50160e3fa58a81412419734c5e8e1b04342fcb4b964d'
             'SKIP'
             '1ddd4443470ad66aff8075e0528ad7757de41d474152db1362e23be72e243919'
             '6b4da532421cac5600d09c0c52742aa52d848af098f7853abe60c02e9d0a3752'
@@ -261,8 +261,8 @@ sha256sums=('57b2cf6991910e3b67a1b3490022e8a0674b6965c74c12da1e99d138d1991ee8'
             '9dfa9f02d17c5cd9620fa2c1d43ca967b81b6a56d33c2bafae14e0c64e498baa'
             '9640178d6251686c980c30fc528b3d70beac6ce8246bf433506a3f843808326c'
             '90a6012cdd8a64ede8e0bbaf7331960bd68f628e0973b65459188eb1ccb5b829'
-            '66e91a3c4616a6c1dfaade969c78f8b3799006d208ac5b5ef314589ba684afce'
-            '8f5f6321d90a2c4e753d993e5ec5c8ad78ddb4415f5306117b40f40dd9e42af2'
+            '903c9e2d141ddb4ebc7f60fd08b54d97306a187a06bfc8832bc8f442f00027e3'
+            'fbbbb17f657d72a36677b556b2b61594a3389191d05de4e4a3a446daab260667'
             'e9e564bdd8f45c552c0f1b32ffa142c887f449f9aadcd190f8d7d143c7567259'
             '31e414978a947bdb71f27ed364c4da73b81fcf1921250cb69ee1bcf2bbd25636'
             '57731fa10509eb689649e6d1ea33b2c3e20a8116617bd848b565d42379b2b6b6')

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mbp-16.1-linux-wifi - 5.15
+mbp-16.1-linux-wifi - 5.14.13
 ==============
 
 Arch Linux package for Linux kernel with bleeding edge 2018+ MacBook Pro support.


### PR DESCRIPTION
Reverts jamlam/mbp-16.1-linux-wifi#26 - This seems to break NVME (at least on my machine)